### PR TITLE
move_loginbutton

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,7 +26,7 @@
             </button>
               <div id="menu" class="collapse navbar-collapse ">
             <ul class="navbar-nav navbar-nav-extend ml-auto">
-              <li class="nav-item nav-item-extend nav-link "><%= link_to "Log in", login_path , class: "btn btn-outline-success "%></li>
+              <%# <li class="nav-item nav-item-extend nav-link "><%= link_to "Log in", login_path , class: "btn btn-outline-success "%></li>
             </ul>
           <% end %>
     </nav>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -35,7 +35,8 @@
     <p class="huwari">１年分、１ヶ月分、１週間分など</p>
     <p class="huwari">期間ごとに時間を計測することができます</p>
   </div>
-  <%= link_to "始める", signup_path, class: "btn-box" %>
+  <%= link_to "新規登録", signup_path, class: "btn-box" %>
+  <%= link_to "ログイン", login_path , class: "btn-box"%>
 </div>
 <section class="service2 container">
   <h2>D2Dだから続けられる<br>日々の積み上げ</h2>
@@ -63,16 +64,11 @@
 
 <script>
     $(function(){
-    $(window).scroll(function (){
+    $(window).on("load", function (){ //ページ読み込み時に表示
         $('.huwari').each(function(){
-            var targetElement = $(this).offset().top;
-            var scroll = $(window).scrollTop();
-            var windowHeight = $(window).height();
-            if (scroll > targetElement - windowHeight + 0){
                 $(this).css('opacity','1');
                 $(this).css('transform','translateY(0)');
-            }
-        });
+            });
     });
 });
 </script>


### PR DESCRIPTION
# what
loginボタンをヘッダーからページ内に移動
ホーム画面のjqueryをロード時読み込みに変更

# why
ヘッダーログインが直感的ではない
＆現時点では新規登録Email認証などの手間を取らないことを優先するため